### PR TITLE
Fix coverage

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
-  config.eager_load = ENV['CI'].present?
+  config.eager_load = true
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,20 +2,7 @@
 
 require 'simplecov'
 
-SimpleCov.start 'rails' do
-  if ENV['CI'].present?
-    require 'simplecov-lcov'
-
-    SimpleCov::Formatter::LcovFormatter.config do |c|
-      c.report_with_single_file = true
-      c.single_report_path = 'coverage/lcov.info'
-    end
-
-    formatter SimpleCov::Formatter::LcovFormatter
-  end
-
-  add_filter %w[version.rb initializer.rb]
-end
+SimpleCov.start 'rails'
 
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
@@ -25,6 +12,14 @@ require 'policy_assertions'
 module ActiveSupport
   class TestCase
     parallelize(workers: :number_of_processors)
+
+    parallelize_setup do |worker|
+      SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
+    end
+
+    parallelize_teardown do |worker|
+      SimpleCov.result
+    end
 
     fixtures :all
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,16 @@
 
 require 'simplecov'
 
-SimpleCov.start 'rails'
+SimpleCov.start 'rails' do
+  require 'simplecov-lcov'
+
+  SimpleCov::Formatter::LcovFormatter.config do |c|
+    c.report_with_single_file = true
+    c.single_report_path = 'coverage/lcov.info'
+  end
+
+  formatter SimpleCov::Formatter::LcovFormatter
+end
 
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ module ActiveSupport
       SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
     end
 
-    parallelize_teardown do |worker|
+    parallelize_teardown do
       SimpleCov.result
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@
 require 'simplecov'
 
 SimpleCov.start 'rails' do
-  if ENV['CI']
+  if ENV['CI'].present?
     require 'simplecov-lcov'
 
     SimpleCov::Formatter::LcovFormatter.config do |c|


### PR DESCRIPTION
Minitest parallel tests don't play nice with Simplecov, as multiple threads cause the coverage results to belong to the slowest thread.

This workaround makes it work: https://github.com/simplecov-ruby/simplecov/issues/718#issuecomment-538201587